### PR TITLE
Moving to Emscripten Docker

### DIFF
--- a/src/app/wasm/3d-cube/build-cmd.js
+++ b/src/app/wasm/3d-cube/build-cmd.js
@@ -1,2 +1,2 @@
 exports.cmd =
-  'emcc -Os src/app/wasm/3d-cube/soil/libSOIL.bc src/app/wasm/3d-cube/3d-cube.c -o src/assets/wasm/3d-cube.js -s LEGACY_GL_EMULATION=1 -Isrc/app/wasm/3d-cube/soil -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s FORCE_FILESYSTEM=1 -s MODULARIZE=1 -s EXPORT_NAME="Cube3dModule"';
+  'docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk emcc -Os src/app/wasm/3d-cube/soil/libSOIL.bc src/app/wasm/3d-cube/3d-cube.c -o src/assets/wasm/3d-cube.js -s LEGACY_GL_EMULATION=1 -Isrc/app/wasm/3d-cube/soil -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s FORCE_FILESYSTEM=1 -s MODULARIZE=1 -s EXPORT_NAME="Cube3dModule"';

--- a/src/app/wasm/bmp-to-ascii/build-cmd.js
+++ b/src/app/wasm/bmp-to-ascii/build-cmd.js
@@ -1,2 +1,2 @@
 exports.cmd =
-  "em++ -Os src/app/wasm/bmp-to-ascii/bmp-to-ascii.cpp -o src/assets/wasm/bmp-to-ascii.js --use-preload-plugins -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['ccall','FS_readFile']\" -s MODULARIZE=1 -s EXPORT_NAME=\"BmpAsciiModule\"";
+  "docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk em++ -Os src/app/wasm/bmp-to-ascii/bmp-to-ascii.cpp -o src/assets/wasm/bmp-to-ascii.js --use-preload-plugins -s EXTRA_EXPORTED_RUNTIME_METHODS=\"['ccall','FS_readFile']\" -s MODULARIZE=1 -s EXPORT_NAME=\"BmpAsciiModule\"";

--- a/src/app/wasm/console-logger/build-cmd.js
+++ b/src/app/wasm/console-logger/build-cmd.js
@@ -1,2 +1,2 @@
 exports.cmd =
-  'emcc -Os src/app/wasm/console-logger/console-logger.c -o src/assets/wasm/console-logger.js -s MODULARIZE=1 -s EXPORT_NAME="ConsoleLoggerModule"';
+  'docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk emcc -Os src/app/wasm/console-logger/console-logger.c -o src/assets/wasm/console-logger.js -s MODULARIZE=1 -s EXPORT_NAME="ConsoleLoggerModule"';

--- a/src/app/wasm/fibonacci/build-cmd.js
+++ b/src/app/wasm/fibonacci/build-cmd.js
@@ -1,1 +1,2 @@
-exports.cmd = "emcc -Os src/app/wasm/fibonacci/fibonacci.c -s STANDALONE_WASM=1 -o src/assets/wasm/fibonacci.wasm";
+exports.cmd =
+    "docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk emcc -Os src/app/wasm/fibonacci/fibonacci.c -o src/assets/wasm/fibonacci.wasm --no-entry";

--- a/src/app/wasm/proof-of-work/build-cmd.js
+++ b/src/app/wasm/proof-of-work/build-cmd.js
@@ -1,2 +1,2 @@
 exports.cmd =
-  'emcc -Os src/app/wasm/proof-of-work/sha256/sha256.c src/app/wasm/proof-of-work/proof-of-work.c -o src/assets/wasm/proof-of-work.js -s ALLOW_MEMORY_GROWTH=1 -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s ASYNCIFY=1 --js-library src/app/wasm/proof-of-work/proof-of-work.emlib.js -s MODULARIZE=1 -s EXPORT_NAME="ProofOfWorkModule"';
+  'docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk emcc -Os src/app/wasm/proof-of-work/sha256/sha256.c src/app/wasm/proof-of-work/proof-of-work.c -o src/assets/wasm/proof-of-work.js -s ALLOW_MEMORY_GROWTH=1 -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s ASYNCIFY=1 --js-library src/app/wasm/proof-of-work/proof-of-work.emlib.js -s MODULARIZE=1 -s EXPORT_NAME="ProofOfWorkModule"';

--- a/src/app/wasm/text-to-ascii/build-cmd.js
+++ b/src/app/wasm/text-to-ascii/build-cmd.js
@@ -1,2 +1,2 @@
 exports.cmd =
-  'em++ -Os src/app/wasm/text-to-ascii/text-to-ascii.cpp -o src/assets/wasm/text-to-ascii.js --preload-file src/app/wasm/text-to-ascii/text-to-ascii.font.txt -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s MODULARIZE=1 -s EXPORT_NAME="TextAsciiModule"';
+  'docker run --rm -v $(pwd):/src -u $(id -u):$(id -g) emscripten/emsdk em++ -Os src/app/wasm/text-to-ascii/text-to-ascii.cpp -o src/assets/wasm/text-to-ascii.js --preload-file src/app/wasm/text-to-ascii/text-to-ascii.font.txt -s EXTRA_EXPORTED_RUNTIME_METHODS="[\'ccall\']" -s MODULARIZE=1 -s EXPORT_NAME="TextAsciiModule"';


### PR DESCRIPTION
Move the build scripts to use the official Docker image instead of people having to install and configure Emscripten (emcc, em++) locally.